### PR TITLE
fix: rgbw2 naming

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -11,6 +11,9 @@ sources:             [src]
 filesystem:          [fs]
 tags:                [c, tuya, tasmota, mongoose]
 
+cflags:
+  - "-Wno-error"
+
 # Custom configuration
 config_schema:
   #### sys ####
@@ -88,7 +91,7 @@ conds:
         MGOS_ROOT_FS_TYPE: SPIFFS
   - when: build_vars.MODEL == "ShellyRGBW2"
     apply:
-      name: rgbw2
+      name: rgbw2-color
       build_vars:
         FS_SIZE: 262144
         FLASH_SIZE: 2097152


### PR DESCRIPTION
I tried to flash a RGBW2 today, and it wasn't working. I was in color mode, and the latest firmware and the debug log reported it was rejecting the new firmware due to the name mismatch.

I also had to add the cflags as it was failing to build with a bunch of warnings about argument types in a lot of the log lines

For anyone who has the same issue, a fixed build of the rgbw2 firmware:
[shelly-rgbw2.zip](https://github.com/arendst/mgos-to-tasmota/files/11715585/shelly-rgbw2.zip)
